### PR TITLE
use streaming/iterators, swap eyes, fix audio, add option to use depth video file

### DIFF
--- a/frames.py
+++ b/frames.py
@@ -10,24 +10,19 @@ import itertools
 
 
 def video_frames(video_path):
-    print('Loading video frames...')
-
     video = cv2.VideoCapture(video_path)
     frames_quantity = int(video.get(cv2.CAP_PROP_FRAME_COUNT))
     fps_count = video.get(cv2.CAP_PROP_FPS)
     progress = tqdm(total=frames_quantity)
     
     def get_frames():
-        num_frames = 0
         success = True
         while success:
             success, image = video.read()
             if success:
                 progress.update(1)
-                num_frames += 1
                 yield(image)
 
-        print(f'Done. Got {num_frames} frames')
     return (get_frames(), fps_count)
 
 
@@ -91,8 +86,6 @@ def frames_to_vid(frames, output_video_path, fps=30):
 
     fourcc = cv2.VideoWriter_fourcc(*'mp4v')
     video = cv2.VideoWriter(output_video_path, fourcc, fps, frame_size)
-
-    print("write iteration start!")
 
     for frame in itertools.chain([first_frame], frames):
         if len(first_frame.shape) == 2:  # Greyscale image

--- a/frames.py
+++ b/frames.py
@@ -74,12 +74,10 @@ def concat_frames(input_folder, output_video_path, fps=30):
     video.release()
 
 
-def frames_to_vid(frames, output_video_path, fps=30):
-    print("frames to vid start!")
+def vid_generator(frames, output_video_path, fps=30):
     if not frames:
         raise ValueError('Empty frames list')
 
-    #frames = iter(frames)
     first_frame = next(frames)
     frame_height, frame_width = first_frame.shape[:2]
     frame_size = (frame_width, frame_height)
@@ -91,6 +89,7 @@ def frames_to_vid(frames, output_video_path, fps=30):
         if len(first_frame.shape) == 2:  # Greyscale image
             frame = cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
         video.write(frame)
+        yield
 
     cv2.destroyAllWindows()
     video.release()

--- a/frames.py
+++ b/frames.py
@@ -1,10 +1,12 @@
 import os
 
 import cv2
-import tqdm
+from tqdm import tqdm
 
 from img_depth import to_depth
 from stereo import create_stereo_pair, concatenate_stereo_pair
+
+import itertools
 
 
 def video_frames(video_path):
@@ -12,17 +14,22 @@ def video_frames(video_path):
 
     video = cv2.VideoCapture(video_path)
     frames_quantity = int(video.get(cv2.CAP_PROP_FRAME_COUNT))
-    progress = tqdm.tqdm(total=frames_quantity)
-    success = True
-    frames = []
-    while success:
-        success, image = video.read()
-        if success:
-            frames.append(image)
-            progress.update(1)
+    fps_count = video.get(cv2.CAP_PROP_FPS)
+    progress = tqdm(total=frames_quantity)
+    
+    def get_frames():
+        num_frames = 0
+        success = True
+        while success:
+            success, image = video.read()
+            if success:
+                progress.update(1)
+                num_frames += 1
+                yield(image)
 
-    print(f'Done. Got {len(frames)} frames')
-    return frames
+        print(f'Done. Got {num_frames} frames')
+    return (get_frames(), fps_count)
+
 
 
 def extract_frames(video_path, output_folder):
@@ -33,7 +40,7 @@ def extract_frames(video_path, output_folder):
     print(f'Video loaded. FPS: {video.get(cv2.CAP_PROP_FPS)}')
 
     frames_quantity = int(video.get(cv2.CAP_PROP_FRAME_COUNT))
-    progress = tqdm.tqdm(total=frames_quantity)
+    progress = tqdm(total=frames_quantity)
     count = 0
     success = True
     frames = []
@@ -44,11 +51,11 @@ def extract_frames(video_path, output_folder):
             progress.update(1)
 
     stereo_frames = []
-    for image, depth in tqdm.tqdm(frames):
+    for image, depth in tqdm(frames):
         stereo = create_stereo_pair(image, depth)
         stereo_frames.append(concatenate_stereo_pair(*stereo))
 
-    for i, frame in enumerate(tqdm.tqdm(stereo_frames)):
+    for i, frame in enumerate(tqdm(stereo_frames)):
         cv2.imwrite(os.path.join(output_folder, f'frame_{i}.jpg'), frame)
 
     video.release()
@@ -73,17 +80,22 @@ def concat_frames(input_folder, output_video_path, fps=30):
 
 
 def frames_to_vid(frames, output_video_path, fps=30):
+    print("frames to vid start!")
     if not frames:
         raise ValueError('Empty frames list')
 
-    frame_height, frame_width = frames[0].shape[:2]
+    #frames = iter(frames)
+    first_frame = next(frames)
+    frame_height, frame_width = first_frame.shape[:2]
     frame_size = (frame_width, frame_height)
 
     fourcc = cv2.VideoWriter_fourcc(*'mp4v')
     video = cv2.VideoWriter(output_video_path, fourcc, fps, frame_size)
 
-    for frame in frames:
-        if len(frames[0].shape) == 2:  # Greyscale image
+    print("write iteration start!")
+
+    for frame in itertools.chain([first_frame], frames):
+        if len(first_frame.shape) == 2:  # Greyscale image
             frame = cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
         video.write(frame)
 

--- a/frames.py
+++ b/frames.py
@@ -74,7 +74,7 @@ def concat_frames(input_folder, output_video_path, fps=30):
     video.release()
 
 
-def vid_generator(frames, output_video_path, fps=30):
+def video_generator(frames, output_video_path, fps=30):
     if not frames:
         raise ValueError('Empty frames list')
 

--- a/main.py
+++ b/main.py
@@ -6,66 +6,37 @@ from datetime import datetime
 from tqdm import tqdm
 from absl import flags, app
 
-from frames import video_frames, frames_to_vid
+from frames import video_frames, vid_generator
 from img_depth import to_depth
 from stereo import create_stereo_pair, concatenate_stereo_pair
 from audio import extract_and_add_audio
-
-
-def hash_file(filepath):
-    # Initialize the SHA-512 hash object
-    hash_object = hashlib.sha512()
-
-    # Open the file in binary read mode and read it in 4096-byte blocks
-    with open(filepath, 'rb') as file:
-        for data_block in iter(lambda: file.read(4096), b""):
-            hash_object.update(data_block)
-
-    # Return the hexadecimal digest of the hash
-    return hash_object.hexdigest()
-
-def pickle_iter(data_it, filename):
-    with open(filename, 'wb') as file:
-        for x in data_it:
-            pickle.dump(x, file)
-def unpickle_iter(filename):
-    with open(filename, 'rb') as file:
-        while file.peek(1):
-            yield pickle.load(file)
-
+from itertools import tee
 
 def main(argv):
     current_datetime = datetime.now().strftime('%Y%m%d-%H%M')
 
     video_path = FLAGS.input_video
-    video_hash_path = os.path.join(FLAGS.output_dir, hash_file(video_path))
-    os.makedirs(video_hash_path, exist_ok=True)
 
-
-    depth_file_path = os.path.join(video_hash_path, f'depth_{FLAGS.depth_model}.pickle')
-    if not os.path.exists(depth_file_path):
-        frames_list, fps = video_frames(video_path)
-        # Calculate depth for each frame using the specified depth model
-        depth_data = (to_depth(frame, FLAGS.depth_model) for frame in tqdm(frames_list))
-        pickle_iter(depth_data, depth_file_path)
-    
-    depth_data = unpickle_iter(depth_file_path)
-
-    if FLAGS.save_depth:
-        depth_video_path = os.path.join(FLAGS.output_dir, f'{current_datetime}_depth_{FLAGS.depth_model}.mp4')
-        frames_to_vid(depth_data, depth_video_path)
-        depth_data = unpickle_iter(depth_file_path) # iterator got used up
-        # extract_and_add_audio(video_path, depth_video_path, depth_video_path)
+    frames_list, fps = video_frames(video_path)
+    frames_list, frames_list2 = tee(frames_list)
+    depth_data = (to_depth(frame, FLAGS.depth_model) for frame in frames_list2)
+    depth_data, depth_data2 = tee(depth_data)
 
 
     # Create stereo pairs and concatenate them
-    frames_list, fps = video_frames(video_path)
     stereo_pairs = (create_stereo_pair(frame, depth) for frame, depth in zip(frames_list, depth_data))
     stereo_frames = (concatenate_stereo_pair(left, right) for left, right in stereo_pairs)
 
     result_video_path_noaudio = os.path.join(FLAGS.output_dir, f'{current_datetime}-noaudio.mp4')
     result_video_path = os.path.join(FLAGS.output_dir, f'{current_datetime}.mp4')
-    frames_to_vid(stereo_frames, result_video_path_noaudio, fps)
+    vid_out = vid_generator(stereo_frames, result_video_path_noaudio, fps)
+
+    if FLAGS.save_depth:
+        depth_video_path = os.path.join(FLAGS.output_dir, f'{current_datetime}_depth_{FLAGS.depth_model}.mp4')
+        vid_out = zip(vid_out, vid_generator(depth_data2, depth_video_path, fps))
+        # extract_and_add_audio(video_path, depth_video_path, depth_video_path)
+    
+    [*vid_out]
     extract_and_add_audio(video_path, result_video_path_noaudio, result_video_path)
 
 

--- a/main.py
+++ b/main.py
@@ -19,29 +19,30 @@ def main(argv):
     depth_map_path = FLAGS.input_depth_map
 
     frames_list, fps = video_frames(video_path)
-    frames_list, frames_list2 = tee(frames_list)
 
     if depth_map_path:
         depth_data, _ = video_frames(depth_map_path)
     else:
+        frames_list, frames_list2 = tee(frames_list)
         depth_data = (to_depth(frame, FLAGS.depth_model) for frame in frames_list2)
-    depth_data, depth_data2 = tee(depth_data)
 
     video_generators = []
 
-
-    # Create stereo pairs and concatenate them
-    stereo_pairs = (create_stereo_pair(frame, depth) for frame, depth in zip(frames_list, depth_data))
-    stereo_frames = (concatenate_stereo_pair(left, right) for left, right in stereo_pairs)
-
-    result_video_path_noaudio = os.path.join(FLAGS.output_dir, f'{current_datetime}-noaudio.mp4')
-    result_video_path = os.path.join(FLAGS.output_dir, f'{current_datetime}.mp4')
-    video_generators.append(video_generator(stereo_frames, result_video_path_noaudio, fps))
-
-    if FLAGS.save_depth:
+    if FLAGS.save_depth or FLAGS.save_depth_only:
+        depth_data, depth_data2 = tee(depth_data)
         depth_video_path = os.path.join(FLAGS.output_dir, f'{current_datetime}_depth_{FLAGS.depth_model}.mp4')
         video_generators.append(video_generator(depth_data2, depth_video_path, fps))
         # extract_and_add_audio(video_path, depth_video_path, depth_video_path)
+
+    # Create stereo pairs and concatenate them
+    if not FLAGS.save_depth_only:
+        stereo_pairs = (create_stereo_pair(frame, depth) for frame, depth in zip(frames_list, depth_data))
+        stereo_frames = (concatenate_stereo_pair(left, right) for left, right in stereo_pairs)
+
+        result_video_path_noaudio = os.path.join(FLAGS.output_dir, f'{current_datetime}-noaudio.mp4')
+        result_video_path = os.path.join(FLAGS.output_dir, f'{current_datetime}.mp4')
+        video_generators.append(video_generator(stereo_frames, result_video_path_noaudio, fps))
+
     
     for _ in zip(*video_generators): pass # start process
     if not FLAGS.save_depth_only:
@@ -52,7 +53,7 @@ if __name__ == '__main__':
     flags.DEFINE_string('input_video', None, 'Path to 2D video for processing', required=True)
     flags.DEFINE_string('output_dir', None, 'Path to directory to store resulting videos', required=True)
     flags.DEFINE_bool('save_depth', False, 'Create video of depth map')
-    flags.DEFINE_bool('save_depth_only', False, 'Create video of depth map instead of a 3D Video')
+    flags.DEFINE_bool('save_depth_only', False, 'Create video of depth map only')
     flags.DEFINE_string('input_depth_map', None, 'Path to depth video')
     flags.DEFINE_bool('remove_tmp', False, 'Remove temporary directory')
     flags.DEFINE_enum('depth_model', 'DPT_Large', ['DPT_Large', 'DPT_Hybrid', 'MiDaS_small'], 'Depth model type')

--- a/main.py
+++ b/main.py
@@ -56,6 +56,7 @@ def main(argv):
     if FLAGS.save_depth:
         depth_video_path = os.path.join(FLAGS.output_dir, f'{current_datetime}_depth_{FLAGS.depth_model}.mp4')
         frames_to_vid(depth_data, depth_video_path)
+        depth_data = unpickle_iter(depth_file_path) # iterator got used up
         # extract_and_add_audio(video_path, depth_video_path, depth_video_path)
 
     # Create stereo pairs and concatenate them

--- a/main.py
+++ b/main.py
@@ -41,17 +41,15 @@ def main(argv):
     video_hash_path = os.path.join(FLAGS.output_dir, hash_file(video_path))
     os.makedirs(video_hash_path, exist_ok=True)
 
-    frames_list, fps = video_frames(video_path)
 
     depth_file_path = os.path.join(video_hash_path, f'depth_{FLAGS.depth_model}.pickle')
     if not os.path.exists(depth_file_path):
+        frames_list, fps = video_frames(video_path)
         # Calculate depth for each frame using the specified depth model
         depth_data = (to_depth(frame, FLAGS.depth_model) for frame in tqdm(frames_list))
         pickle_iter(depth_data, depth_file_path)
-        frames_list, fps = video_frames(video_path) # frames_list got used up
     
     depth_data = unpickle_iter(depth_file_path)
-
 
     if FLAGS.save_depth:
         depth_video_path = os.path.join(FLAGS.output_dir, f'{current_datetime}_depth_{FLAGS.depth_model}.mp4')
@@ -59,9 +57,11 @@ def main(argv):
         depth_data = unpickle_iter(depth_file_path) # iterator got used up
         # extract_and_add_audio(video_path, depth_video_path, depth_video_path)
 
+
     # Create stereo pairs and concatenate them
+    frames_list, fps = video_frames(video_path)
     stereo_pairs = (create_stereo_pair(frame, depth) for frame, depth in zip(frames_list, depth_data))
-    stereo_frames = (concatenate_stereo_pair(left, right) for left, right in tqdm(stereo_pairs))
+    stereo_frames = (concatenate_stereo_pair(left, right) for left, right in stereo_pairs)
 
     result_video_path_noaudio = os.path.join(FLAGS.output_dir, f'{current_datetime}-noaudio.mp4')
     result_video_path = os.path.join(FLAGS.output_dir, f'{current_datetime}.mp4')

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from tqdm import tqdm
 from absl import flags, app
 
-from frames import video_frames, vid_generator
+from frames import video_frames, video_generator
 from img_depth import to_depth
 from stereo import create_stereo_pair, concatenate_stereo_pair
 from audio import extract_and_add_audio
@@ -16,11 +16,18 @@ def main(argv):
     current_datetime = datetime.now().strftime('%Y%m%d-%H%M')
 
     video_path = FLAGS.input_video
+    depth_map_path = FLAGS.input_depth_map
 
     frames_list, fps = video_frames(video_path)
     frames_list, frames_list2 = tee(frames_list)
-    depth_data = (to_depth(frame, FLAGS.depth_model) for frame in frames_list2)
+
+    if depth_map_path:
+        depth_data, _ = video_frames(depth_map_path)
+    else:
+        depth_data = (to_depth(frame, FLAGS.depth_model) for frame in frames_list2)
     depth_data, depth_data2 = tee(depth_data)
+
+    video_generators = []
 
 
     # Create stereo pairs and concatenate them
@@ -29,21 +36,24 @@ def main(argv):
 
     result_video_path_noaudio = os.path.join(FLAGS.output_dir, f'{current_datetime}-noaudio.mp4')
     result_video_path = os.path.join(FLAGS.output_dir, f'{current_datetime}.mp4')
-    vid_out = vid_generator(stereo_frames, result_video_path_noaudio, fps)
+    video_generators.append(video_generator(stereo_frames, result_video_path_noaudio, fps))
 
     if FLAGS.save_depth:
         depth_video_path = os.path.join(FLAGS.output_dir, f'{current_datetime}_depth_{FLAGS.depth_model}.mp4')
-        vid_out = zip(vid_out, vid_generator(depth_data2, depth_video_path, fps))
+        video_generators.append(video_generator(depth_data2, depth_video_path, fps))
         # extract_and_add_audio(video_path, depth_video_path, depth_video_path)
     
-    [*vid_out]
-    extract_and_add_audio(video_path, result_video_path_noaudio, result_video_path)
+    for _ in zip(*video_generators): pass # start process
+    if not FLAGS.save_depth_only:
+        extract_and_add_audio(video_path, result_video_path_noaudio, result_video_path)
 
 
 if __name__ == '__main__':
     flags.DEFINE_string('input_video', None, 'Path to 2D video for processing', required=True)
     flags.DEFINE_string('output_dir', None, 'Path to directory to store resulting videos', required=True)
     flags.DEFINE_bool('save_depth', False, 'Create video of depth map')
+    flags.DEFINE_bool('save_depth_only', False, 'Create video of depth map instead of a 3D Video')
+    flags.DEFINE_string('input_depth_map', None, 'Path to depth video')
     flags.DEFINE_bool('remove_tmp', False, 'Remove temporary directory')
     flags.DEFINE_enum('depth_model', 'DPT_Large', ['DPT_Large', 'DPT_Hybrid', 'MiDaS_small'], 'Depth model type')
     FLAGS = flags.FLAGS

--- a/stereo.py
+++ b/stereo.py
@@ -33,8 +33,8 @@ def create_stereo_pair(image, depth_map, baseline_distance=0.005, depth_scale_fa
     displacement = (baseline_distance * (depth_map_normalized * width)).astype(int)
 
     # Apply displacement to get new coordinates for left and right images
-    left_coords_x = np.clip(x_coords + displacement, 0, width - 1)
-    right_coords_x = np.clip(x_coords - displacement, 0, width - 1)
+    left_coords_x = np.clip(x_coords - displacement, 0, width - 1)
+    right_coords_x = np.clip(x_coords + displacement, 0, width - 1)
 
     # Index the original image with new coordinates to create the stereo pair
     left_image = image[y_coords, left_coords_x]

--- a/stereo.py
+++ b/stereo.py
@@ -19,6 +19,10 @@ def create_stereo_pair(image, depth_map, baseline_distance=0.005, depth_scale_fa
     # Ensure the input image and depth map have the same dimensions
     assert image.shape[:2] == depth_map.shape[:2], 'The image and depth map must be the same size.'
 
+    # only use red channel for rgb images
+    if len(depth_map.shape) > 2:
+        depth_map = cv2.split(depth_map)[0]
+
     # Scale and normalize the depth map for processing
     depth_map = depth_map.astype(np.float32) / depth_scale_factor
     depth_map_normalized = cv2.normalize(depth_map, None, 0, 1, cv2.NORM_MINMAX)

--- a/stereo.py
+++ b/stereo.py
@@ -2,54 +2,27 @@ import cv2
 import numpy as np
 
 
-def create_stereo_pair(image, depth_map, baseline_distance=0.005, depth_scale_factor=0.5):
-    """
-    Generates a stereo pair of images (left and right) from a single image and a depth map by simulating
-    the parallax effect seen in stereo vision.
-
-    Parameters:
-    - image: The input image for which the stereo pair will be created.
-    - depth_map: The depth map of the input image. Values represent depth intensity.
-    - baseline_distance: The distance between the two virtual cameras. Default is 0.005.
-    - depth_scale_factor: A scaling factor applied to the depth map to adjust the effect of depth. Default is 0.5.
-
-    Returns:
-    A tuple containing the left and right images of the stereo pair.
-    """
-    # Ensure the input image and depth map have the same dimensions
+def create_stereo_pair(image, depth_map, baseline_distance=0.01, depth_scale_factor=0.15):
     assert image.shape[:2] == depth_map.shape[:2], 'The image and depth map must be the same size.'
-
+    
     # only use red channel for rgb images
     if len(depth_map.shape) > 2:
         depth_map = cv2.split(depth_map)[0]
 
-    # Scale and normalize the depth map for processing
-    depth_map = depth_map.astype(np.float32) / depth_scale_factor
+    depth_map = ((depth_map.astype(np.float32) ** 2) / depth_scale_factor) ** .5
     depth_map_normalized = cv2.normalize(depth_map, None, 0, 1, cv2.NORM_MINMAX)
 
     height, width = image.shape[:2]
+    x_coords = np.tile(np.arange(width), (height, 1)).astype(np.float32)
+    y_coords = np.repeat(np.arange(height), width).reshape(height, width).astype(np.float32)
 
-    # Create coordinate grids for the image pixels
-    x_coords = np.tile(np.arange(width), (height, 1))
-    y_coords = np.repeat(np.arange(height), width).reshape(height, width)
+    displacement = (baseline_distance * (depth_map_normalized * width)).astype(np.float32)
 
-    # Calculate horizontal displacement based on depth
-    displacement = (baseline_distance * (depth_map_normalized * width)).astype(int)
+    left_coords = np.stack((x_coords - displacement, y_coords), axis=-1)
+    right_coords = np.stack((x_coords + displacement, y_coords), axis=-1)
 
-    # Apply displacement to get new coordinates for left and right images
-    left_coords_x = np.clip(x_coords - displacement, 0, width - 1)
-    right_coords_x = np.clip(x_coords + displacement, 0, width - 1)
-
-    # Index the original image with new coordinates to create the stereo pair
-    left_image = image[y_coords, left_coords_x]
-    right_image = image[y_coords, right_coords_x]
-
-    # Fill in the gaps caused by displacement with inpainting
-    left_image_mask = (left_image == 0).all(axis=2)
-    right_image_mask = (right_image == 0).all(axis=2)
-
-    left_image = cv2.inpaint(left_image, left_image_mask.astype(np.uint8) * 255, 3, cv2.INPAINT_TELEA)
-    right_image = cv2.inpaint(right_image, right_image_mask.astype(np.uint8) * 255, 3, cv2.INPAINT_TELEA)
+    left_image = cv2.remap(image, left_coords, None, cv2.INTER_LINEAR)
+    right_image = cv2.remap(image, right_coords, None, cv2.INTER_LINEAR)
 
     return left_image, right_image
 
@@ -79,3 +52,4 @@ def concatenate_stereo_pair(left_image, right_image, separator_width=0, separato
     concatenated_image = np.concatenate((left_image, separator, right_image), axis=1)
 
     return concatenated_image
+    


### PR DESCRIPTION
I changed the program to work with iterators, which means everything is processed frame by frame and my PC can convert a whole movie without running out of memory.

While I was doing that, I also set the correct FPS for the output video,
fixed the audio (I think moviepy doesn't want to write over a file it's also reading from),
and swapped the views so that the left view is on the left.

I got rid of the depth data cache too. Instead I added an option to read the depth map from a video file.

Sorry about putting so much stuff into the PR. I started with the streaming/iterators and changed some other stuff along the way.
I noticed too late that the `fixing_app` branch is newer. It should be possible to port these changes over.